### PR TITLE
[DevOps] Remove non-production dependencies from Snyk scan

### DIFF
--- a/.github/workflows/snyk-scan.yml
+++ b/.github/workflows/snyk-scan.yml
@@ -6,11 +6,10 @@ on:
   push:
     branches:
      - master
-     - devops/snyk-optimization
 
 jobs:
   snyk_scan_test:
-    if: ${{ github.event_name == 'push' }} 
+    if: ${{ github.event_name == 'pull_request' }} 
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master

--- a/.github/workflows/snyk-scan.yml
+++ b/.github/workflows/snyk-scan.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   snyk_scan_test:
-    if: ${{ github.event_name == 'pull_request' }} 
+    if: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master

--- a/.github/workflows/snyk-scan.yml
+++ b/.github/workflows/snyk-scan.yml
@@ -6,10 +6,11 @@ on:
   push:
     branches:
      - master
+     - devops/snyk-optimization
 
 jobs:
   snyk_scan_test:
-    if: ${{ github.event_name == 'pull_request' }}
+    if: ${{ github.event_name == 'push' }} 
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
@@ -35,7 +36,13 @@ jobs:
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         run: |
-          snyk test --file=h2o-java-droplet/build.gradle -d --fail-on=all --package-manager=gradle
+          snyk test \
+            --file=h2o-java-droplet/build.gradle \
+            -d \
+            --fail-on=all \
+            --package-manager=gradle \
+            --print-deps \
+            --configuration-matching='^\(compile\|runtime\)'
 
   snyk_scan_monitor:
     if: ${{ github.event_name == 'push' }}
@@ -58,7 +65,14 @@ jobs:
         run: |
           for file in $(find . -name "build.gradle"); do
             file=${file:2}
-            snyk monitor --org=h2o-3 --remote-repo-url=h2o-droplets/${{ steps.extract_ref.outputs.ref }} --file=$file --project-name=H2O-3/h2o-droplets/${{ steps.extract_ref.outputs.ref }}/$file -d
+            snyk monitor \
+              --org=h2o-3 \
+              --remote-repo-url=h2o-droplets/${{ steps.extract_ref.outputs.ref }} \
+              --file=$file \
+              --project-name=H2O-3/h2o-droplets/${{ steps.extract_ref.outputs.ref }}/$file \
+              -d \
+              --print-deps \
+              --configuration-matching='^\(compile\|runtime\)'
           done
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/h2o-java-droplet/build.gradle
+++ b/h2o-java-droplet/build.gradle
@@ -77,3 +77,4 @@ targetCompatibility = 1.8
 compileJava { 
     options.debug = true 
 }
+

--- a/h2o-java-droplet/build.gradle
+++ b/h2o-java-droplet/build.gradle
@@ -77,4 +77,3 @@ targetCompatibility = 1.8
 compileJava { 
     options.debug = true 
 }
-


### PR DESCRIPTION
### Notes

- Added `--configuration-matching='^\(compile\|runtime\)'` argument to only match dependencies with compile & runtime configurations.
- Formatted & added `--print-deps` for clarity.
- Scan results: https://app.snyk.io/org/h2o-3/projects

### Parent Issue

- https://github.com/h2oai/h2o-ops/issues/311

### References

- https://github.com/h2oai/mojo2/pull/1680/files#diff-aaaabb7a31d2478cd39520b23197235a66b258d3e8ef86976b831a1bec837dd9L52-L86
- https://docs.snyk.io/snyk-cli/commands/monitor#configuration-matching-less-than-configuration_regex-greater-than
- https://docs.snyk.io/snyk-cli/commands/test#configuration-matching-less-than-configuration_regex-greater-than